### PR TITLE
feat: add tag display to setting and page

### DIFF
--- a/VsCode/Classes/SettingsManager.cs
+++ b/VsCode/Classes/SettingsManager.cs
@@ -15,35 +15,53 @@ public class SettingsManager : JsonSettingsManager
 
     private static string Namespaced(string propertyName) => $"{_namespace}.{propertyName}";
 
-    private static readonly List<ChoiceSetSetting.Choice> _choices =
+    private static readonly List<ChoiceSetSetting.Choice> _preferredEditionChoices =
     [
         new ChoiceSetSetting.Choice(Resource.setting_preferredEdition_option_default_label, "Default"),
         new ChoiceSetSetting.Choice(Resource.setting_preferredEdition_option_insider_label, "Insider"),
     ];
+
+    private static readonly List<ChoiceSetSetting.Choice> _tagChoices =
+    [
+        new ChoiceSetSetting.Choice(Resource.setting_tagType_option_none_label, "None"),
+        new ChoiceSetSetting.Choice(Resource.setting_tagType_option_type_label, "Type"),
+        new ChoiceSetSetting.Choice(Resource.setting_tagType_option_target_label, "Target"),
+        new ChoiceSetSetting.Choice(Resource.setting_tagType_option_typeandtarget_label, "TypeAndTarget"),
+    ];
+
 
 
     private readonly ToggleSetting _useStrictSearch = new(
         Namespaced(nameof(UseStrichtSearch)),
         Resource.settings_useStrictSearch_label,
         Resource.settings_useStrictSearch_desc,
-        false); // TODO -- double check default value
+        false);
 
     private readonly ToggleSetting _showDetails = new(
        Namespaced(nameof(ShowDetails)),
        Resource.settings_showDetails_label,
        Resource.settings_showDetails_desc,
-       false); // TODO -- double check default value
+       false);
 
     private readonly ChoiceSetSetting _preferredEdition = new(
         Namespaced(nameof(PreferredEdition)),
         Resource.setting_preferredEdition_label,
         Resource.setting_preferredEdition_desc,
-        _choices);
+        _preferredEditionChoices);
+
+
+
+    private readonly ChoiceSetSetting _tagType = new(
+        Namespaced(nameof(TagType)),
+        Resource.setting_tagType_label,
+        Resource.setting_tagType_desc,
+        _tagChoices);
 
     public bool UseStrichtSearch => _useStrictSearch.Value;
     public bool ShowDetails => _showDetails.Value;
 
     public string PreferredEdition => _preferredEdition.Value ?? "Default";
+    public string TagType => _tagType.Value ?? "Type";
 
 
     internal static string SettingsJsonPath()
@@ -61,6 +79,7 @@ public class SettingsManager : JsonSettingsManager
 
         Settings.Add(_showDetails);
         Settings.Add(_useStrictSearch);
+        Settings.Add(_tagType);
         Settings.Add(_preferredEdition);
 
         // Load settings from file upon initialization

--- a/VsCode/Pages/VSCodePage.cs
+++ b/VsCode/Pages/VSCodePage.cs
@@ -47,7 +47,40 @@ internal sealed partial class VSCodePage : DynamicListPage
                 Metadata = workspace.GetMetadata(),
             };
 
-            items.Add(new ListItem(command) { Title = details.Title, Subtitle = Uri.UnescapeDataString(workspace.Path), Details = details, Icon = workspace.Instance.GetIcon() });
+            var tags = new List<Tag>();
+
+            switch (_settingsManager.TagType)
+            {
+                case "None":
+                    break;
+                case "Type":
+                    tags.Add(new Tag(workspace.GetWorkspaceType()));
+                    if (workspace.GetVSType() != "")
+                    {
+                        tags.Add(new Tag(workspace.GetVSType()));
+                    }
+                    break;
+                case "Target":
+                    tags.Add(new Tag(workspace.Instance.Name));
+                    break;
+                case "TypeAndTarget":
+                    tags.Add(new Tag(workspace.GetWorkspaceType()));
+                    if (workspace.GetVSType() != "")
+                    {
+                        tags.Add(new Tag(workspace.GetVSType()));
+                    }
+                    tags.Add(new Tag(workspace.Instance.Name));
+                    break;
+            }
+
+            items.Add(new ListItem(command)
+            {
+                Title = details.Title,
+                Subtitle = Uri.UnescapeDataString(workspace.Path),
+                Details = details,
+                Icon = workspace.Instance.GetIcon(),
+                Tags = tags.ToArray()
+            });
         }
 
         if (items.Count == 0)

--- a/VsCode/Properties/Resource.Designer.cs
+++ b/VsCode/Properties/Resource.Designer.cs
@@ -160,6 +160,60 @@ namespace CmdPalVsCode.Properties {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Displayed tags ähnelt.
+        /// </summary>
+        internal static string setting_tagType_desc {
+            get {
+                return ResourceManager.GetString("setting_tagType_desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Tags ähnelt.
+        /// </summary>
+        internal static string setting_tagType_label {
+            get {
+                return ResourceManager.GetString("setting_tagType_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die - ähnelt.
+        /// </summary>
+        internal static string setting_tagType_option_none_label {
+            get {
+                return ResourceManager.GetString("setting_tagType_option_none_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Target ähnelt.
+        /// </summary>
+        internal static string setting_tagType_option_target_label {
+            get {
+                return ResourceManager.GetString("setting_tagType_option_target_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Type ähnelt.
+        /// </summary>
+        internal static string setting_tagType_option_type_label {
+            get {
+                return ResourceManager.GetString("setting_tagType_option_type_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Type &amp; Target ähnelt.
+        /// </summary>
+        internal static string setting_tagType_option_typeandtarget_label {
+            get {
+                return ResourceManager.GetString("setting_tagType_option_typeandtarget_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Details panel ähnelt.
         /// </summary>
         internal static string settings_showDetails_desc {

--- a/VsCode/Properties/Resource.resx
+++ b/VsCode/Properties/Resource.resx
@@ -162,4 +162,22 @@
   <data name="settings_showDetails_desc" xml:space="preserve">
     <value>Details panel</value>
   </data>
+  <data name="setting_tagType_label" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="setting_tagType_desc" xml:space="preserve">
+    <value>Displayed tags</value>
+  </data>
+  <data name="setting_tagType_option_none_label" xml:space="preserve">
+    <value>-</value>
+  </data>
+  <data name="setting_tagType_option_type_label" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="setting_tagType_option_target_label" xml:space="preserve">
+    <value>Target</value>
+  </data>
+  <data name="setting_tagType_option_typeandtarget_label" xml:space="preserve">
+    <value>Type &amp; Target</value>
+  </data>
 </root>


### PR DESCRIPTION
This pull request introduces a new "TagType" setting to allow users to customize the tags displayed in the VS Code workspace items. It includes changes to the settings manager, the workspace item rendering logic, and the resource files for localization.

### New "TagType" Setting:

* [`VsCode/Classes/SettingsManager.cs`](diffhunk://#diff-bcda0ffaad776e1a216637684b5fef3f9a7ed9f7ef0c3762db0bf1b6ea43401eL18-R64): Added a new `ChoiceSetSetting` called `_tagType` with options for "None," "Type," "Target," and "TypeAndTarget." This setting determines how tags are displayed for workspace items. [[1]](diffhunk://#diff-bcda0ffaad776e1a216637684b5fef3f9a7ed9f7ef0c3762db0bf1b6ea43401eL18-R64) [[2]](diffhunk://#diff-bcda0ffaad776e1a216637684b5fef3f9a7ed9f7ef0c3762db0bf1b6ea43401eR82)
* `VsCode/Properties/Resource.Designer.cs` and `VsCode/Properties/Resource.resx`: Added localized strings for the "TagType" setting, including its label, description, and option values. [[1]](diffhunk://#diff-d6f6bfade00a65273cb204d0dad13b9f3192bb2423a162e09401c8edfa415ce4R162-R215) [[2]](diffhunk://#diff-7fe81c98351b55f1ca2f0189342744865f699e7e724cd817e9e91052debc202eR165-R182)

### Workspace Item Rendering:

* [`VsCode/Pages/VSCodePage.cs`](diffhunk://#diff-9aab316a168826652abb3b4cf16b94c22a1528748e0118712553b40c9d934688L50-R83): Updated the `GetItems` method to include logic for rendering tags based on the selected "TagType" setting. Tags can now display workspace type, VS type, target, or a combination of these, depending on the user's choice.