### PR TITLE
feat: pass VSCodePage instance to OpenVSCodeCommand for search text reset

### DIFF
--- a/VsCode/Commands/OpenVsCodeCommand.cs
+++ b/VsCode/Commands/OpenVsCodeCommand.cs
@@ -10,16 +10,18 @@ internal sealed partial class OpenVSCodeCommand : InvokableCommand
     public override string Name => "Open VS Code";
     private string workspacePath;
     private string executablePath;
+    private VSCodePage page;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenVSCodeCommand"/> class.
     /// </summary>
     /// <param name="executablePath">The path to the VS Code executable.</param>
     /// <param name="workspacePath">The path to the workspace to open.</param>
-    public OpenVSCodeCommand(string executablePath, string workspacePath)
+    public OpenVSCodeCommand(string executablePath, string workspacePath, VSCodePage page)
     {
         this.workspacePath = workspacePath;
         this.executablePath = executablePath;
+        this.page = page;
     }
 
     /// <summary>
@@ -40,6 +42,9 @@ internal sealed partial class OpenVSCodeCommand : InvokableCommand
         }
 
         ShellHelpers.OpenInShell(executablePath, arguments, null, ShellHelpers.ShellRunAsType.None, false);
+
+        // reset search text
+        page.UpdateSearchText(page.SearchText, string.Empty);
 
         return CommandResult.Hide();
     }

--- a/VsCode/Package.appxmanifest
+++ b/VsCode/Package.appxmanifest
@@ -12,7 +12,7 @@
 	<Identity
 	  Name="JonahFintzDEV.602808C55E867"
 	  Publisher="CN=240FD63B-E96D-4F79-A6D2-BFC6E6AD6C10"
-	  Version="1.3.0.0" />
+	  Version="1.4.0.0" />
 
 	
 	<Properties>

--- a/VsCode/Pages/VSCodePage.cs
+++ b/VsCode/Pages/VSCodePage.cs
@@ -38,7 +38,7 @@ internal sealed partial class VSCodePage : DynamicListPage
         foreach (var workspace in VSCodeHandler.GetWorkspaces())
         {
             // add instance to the list
-            var command = new OpenVSCodeCommand(workspace.Instance.ExecutablePath, workspace.Path);
+            var command = new OpenVSCodeCommand(workspace.Instance.ExecutablePath, workspace.Path, this);
 
             Details details = new Details()
             {


### PR DESCRIPTION
This pull request updates the `OpenVSCodeCommand` class to include functionality for resetting the search text in the `VSCodePage` after invoking the command. It introduces a new dependency on the `VSCodePage` class and modifies related methods to support this behavior.

### Updates to `OpenVSCodeCommand`:

* Added a new private field `page` to store a reference to the `VSCodePage` instance. (`[VsCode/Commands/OpenVsCodeCommand.csR13-R24](diffhunk://#diff-dbb85ec41d70bfd8b29a78c37a8b55d382fe5c238780bb2e8b918e59af9a67dcR13-R24)`)
* Updated the constructor of `OpenVSCodeCommand` to accept a `VSCodePage` parameter and initialize the `page` field. (`[VsCode/Commands/OpenVsCodeCommand.csR13-R24](diffhunk://#diff-dbb85ec41d70bfd8b29a78c37a8b55d382fe5c238780bb2e8b918e59af9a67dcR13-R24)`)
* Modified the `Invoke` method to reset the search text in the associated `VSCodePage` by calling `page.UpdateSearchText`. (`[VsCode/Commands/OpenVsCodeCommand.csR46-R48](diffhunk://#diff-dbb85ec41d70bfd8b29a78c37a8b55d382fe5c238780bb2e8b918e59af9a67dcR46-R48)`)

### Updates to `VSCodePage`:

* Updated the `GetItems` method to pass the current `VSCodePage` instance when creating `OpenVSCodeCommand` objects, ensuring the command has access to the page. (`[VsCode/Pages/VSCodePage.csL41-R41](diffhunk://#diff-9aab316a168826652abb3b4cf16b94c22a1528748e0118712553b40c9d934688L41-R41)`)